### PR TITLE
Cleaned up analytical_line.py for PR

### DIFF
--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -46,7 +46,7 @@ from isofit.utils                    import remap
 from isofit.utils.atm_interpolation  import atm_interpolation
 
 
-def main(rawargs=None):
+def main(rawargs=None) -> None:
     """
     TODO: Description
     """
@@ -120,9 +120,10 @@ def main(rawargs=None):
     if 'emit pge input files' in list(output_metadata.keys()):
         del output_metadata['emit pge input files']
 
-    del envi.create_image(envi_header(analytical_state_file),     ext='', metadata=output_metadata, force=True)
-    del envi.create_image(envi_header(analytical_state_unc_file), ext='', metadata=output_metadata, force=True)
-    del atm, rdn
+    img = envi.create_image(envi_header(analytical_state_file),     ext='', metadata=output_metadata, force=True)
+    del img
+    img = envi.create_image(envi_header(analytical_state_unc_file), ext='', metadata=output_metadata, force=True)
+    del atm, rdn, img
 
     ray.init(
         ignore_reinit_error = config.implementation.ray_ignore_reinit_error,
@@ -192,7 +193,7 @@ class Worker(object):
         self.analytical_state_file = analytical_state_file
         self.analytical_state_unc_file = analytical_state_unc_file
 
-    def run_lines(self, startstop: tuple):
+    def run_lines(self, startstop: tuple) -> None:
         """
         TODO: Description
         """

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -18,53 +18,68 @@
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 
 import argparse
-import os
-from spectral.io import envi
-import numpy as np
-from glob import glob
 import logging
+import numpy as np
+import os
 import ray
 import time
 
-from isofit.utils import remap
-from isofit.core.common import envi_header, svd_inv, svd_inv_sqrt
-from isofit.configs import configs
-from isofit.core.forward import ForwardModel
-from isofit.inversion.inverse import Inversion
-from isofit.inversion.inverse_simple import invert_algebraic, invert_analytical
-from isofit.core.geometry import Geometry
-from isofit.core.fileio import write_bil_chunk
-
-from isofit.utils.atm_interpolation import atm_interpolation
 from collections import OrderedDict
+from glob        import glob
+from spectral.io import envi
+
+from isofit.configs                  import configs
+from isofit.core.common              import (
+    envi_header,
+    svd_inv,
+    svd_inv_sqrt
+)
+from isofit.core.fileio              import write_bil_chunk
+from isofit.core.forward             import ForwardModel
+from isofit.core.geometry            import Geometry
+from isofit.inversion.inverse        import Inversion
+from isofit.inversion.inverse_simple import (
+    invert_algebraic,
+    invert_analytical
+)
+from isofit.utils                    import remap
+from isofit.utils.atm_interpolation  import atm_interpolation
 
 
 def main(rawargs=None):
-    parser = argparse.ArgumentParser(description="Apply OE to a block of data.")
-    parser.add_argument('rdn_file', type=str)
-    parser.add_argument('loc_file', type=str)
-    parser.add_argument('obs_file', type=str)
-    parser.add_argument('isofit_dir', type=str)
-    parser.add_argument('--n_atm_neighbors', type=int, default=20)
-    parser.add_argument('--smoothing_sigma', type=int, default=2)
-    parser.add_argument('--output_rfl_file', type=str, default=None)
-    parser.add_argument('--output_unc_file', type=str, default=None)
-    parser.add_argument('--atm_file', type=str, default=None)
-    parser.add_argument('--loglevel', type=str, default='INFO')
-    parser.add_argument('--logfile', type=str, default=None)
+    """
+    TODO: Description
+    """
+    # TODO: Parser should be moved out of main and these be made parameters of the function
+    parser = argparse.ArgumentParser(description='Apply OE to a block of data.')
+    parser.add_argument('rdn_file',          type=str                )
+    parser.add_argument('loc_file',          type=str                )
+    parser.add_argument('obs_file',          type=str                )
+    parser.add_argument('isofit_dir',        type=str                )
+    parser.add_argument('--n_atm_neighbors', type=int, default=20    )
+    parser.add_argument('--smoothing_sigma', type=int, default=2     )
+    parser.add_argument('--output_rfl_file', type=str, default=None  )
+    parser.add_argument('--output_unc_file', type=str, default=None  )
+    parser.add_argument('--atm_file',        type=str, default=None  )
+    parser.add_argument('--loglevel',        type=str, default='INFO')
+    parser.add_argument('--logfile',         type=str, default=None  )
     args = parser.parse_args(rawargs)
 
-    logging.basicConfig(format='%(levelname)s:%(asctime)s ||| %(message)s', level=args.loglevel,
-                            filename=args.logfile, datefmt='%Y-%m-%d,%H:%M:%S')
+    logging.basicConfig(
+        format   = '%(levelname)s:%(asctime)s ||| %(message)s',
+        level    = args.loglevel,
+        filename = args.logfile, datefmt='%Y-%m-%d,%H:%M:%S'
+    )
 
-    config_file = glob(os.path.join(args.isofit_dir, 'config','') + '*_modtran.json')[0]
-    config = configs.create_new_config(config_file)
+    file   = glob(os.path.join(args.isofit_dir, 'config', '') + '*_modtran.json')[0]
+    config = configs.create_new_config(file)
     config.forward_model.instrument.integrations = 1
 
     subs_state_file = config.output.estimated_state_file
-    subs_loc_file = config.input.loc_file
-    full_state_file = subs_state_file.replace('_subs_state', '_subs_state_mapped')
-    lbl_file = subs_state_file.replace('_subs_state', '_lbl')
+    subs_loc_file   = config.input.loc_file
+    full_state_file = subs_state_file.replace('_subs_state', '_subs_state_mapped') # Unused
+    lbl_file        = subs_state_file.replace('_subs_state', '_lbl')
+
     if args.output_rfl_file is None:
         analytical_state_file = subs_state_file.replace('_subs_state', '_state_analytical')
     else:
@@ -81,65 +96,75 @@ def main(rawargs=None):
         atm_file = args.atm_file
 
     if os.path.isfile(atm_file) is False:
-       atm_interpolation(subs_state_file, subs_loc_file, lbl_file, args.loc_file, atm_file, 
-                          nneighbors=args.n_atm_neighbors, gaussian_smoothing_sigma=args.smoothing_sigma) 
+        atm_interpolation(subs_state_file, subs_loc_file, lbl_file, args.loc_file, atm_file,
+            nneighbors               = args.n_atm_neighbors,
+            gaussian_smoothing_sigma = args.smoothing_sigma
+        )
 
     fm = ForwardModel(config)
     iv = Inversion(config, fm)
 
     rdn_ds = envi.open(envi_header(args.rdn_file))
-    rdn = rdn_ds.open_memmap(interleave='bip')
-    rdns = rdn.shape
-    loc = envi.open(envi_header(args.loc_file)).open_memmap(interleave='bip')#
-    obs = envi.open(envi_header(args.obs_file)).open_memmap(interleave='bip')#
-    atm = envi.open(envi_header(atm_file)).open_memmap(interleave='bip')
+    rdn    = rdn_ds.open_memmap(interleave='bip')
+    rdns   = rdn.shape
+    loc    = envi.open(envi_header(args.loc_file)).open_memmap(interleave='bip')
+    obs    = envi.open(envi_header(args.obs_file)).open_memmap(interleave='bip')
+    atm    = envi.open(envi_header(atm_file)).open_memmap(interleave='bip')
 
-    hash_table = OrderedDict()
-    hash_size = 500
-    
-    output_metadata = rdn_ds.metadata
-    output_metadata['interleave'] = 'bil'
+    hash_table = OrderedDict() # Deprecated in Python 3.7
+    hash_size  = 500 # Unused, hardcoded
+
+    output_metadata                = rdn_ds.metadata
+    output_metadata['interleave']  = 'bil'
     output_metadata['description'] = 'L2A Analytyical per-pixel surface retrieval'
     if 'emit pge input files' in list(output_metadata.keys()):
         del output_metadata['emit pge input files']
-    
-    output_reflectance_img = envi.create_image(envi_header(analytical_state_file), ext='',
-                                               metadata=output_metadata, force=True)
-    del output_reflectance_img
-    output_reflectance_unc_img = envi.create_image(envi_header(analytical_state_unc_file), ext='',
-                                                   metadata=output_metadata, force=True)
-    del output_reflectance_unc_img
+
+    del envi.create_image(envi_header(analytical_state_file),     ext='', metadata=output_metadata, force=True)
+    del envi.create_image(envi_header(analytical_state_unc_file), ext='', metadata=output_metadata, force=True)
     del atm, rdn
 
-    rayargs = {'ignore_reinit_error': config.implementation.ray_ignore_reinit_error,
-               "address": config.implementation.ip_head,
-               '_temp_dir': config.implementation.ray_temp_dir,
-               'include_dashboard': config.implementation.ray_include_dashboard,
-               "_redis_password": config.implementation.redis_password}
+    ray.init(
+        ignore_reinit_error = config.implementation.ray_ignore_reinit_error,
+        address             = config.implementation.ip_head,
+        _temp_dir           = config.implementation.ray_temp_dir,
+        include_dashboard   = config.implementation.ray_include_dashboard,
+        _redis_password     = config.implementation.redis_password
+    )
 
+    n_workers = 40 # Hardcoded
+    worker    = ray.remote(Worker)
+    wargs     = [
+        config, ray.put(fm), atm_file, analytical_state_file, analytical_state_unc_file,
+        args.rdn_file, args.loc_file, args.obs_file, args.loglevel, args.logfile
+    ]
+    workers = ray.util.ActorPool([worker.remote(*wargs) for _ in range(n_workers)])
 
-    ray.init(**rayargs)
-    fm_id = ray.put(fm)
-    remote_worker = ray.remote(Worker)
-    n_workers = 40
-    workers = ray.util.ActorPool([remote_worker.remote(config, fm_id, atm_file, 
-                                  analytical_state_file, analytical_state_unc_file, args.rdn_file, args.loc_file, args.obs_file,
-                                  args.loglevel, args.logfile) for n in range(n_workers)])
-
-    line_breaks = np.linspace(0,rdns[0], n_workers*3,dtype=int)
+    line_breaks = np.linspace(0,rdns[0], n_workers*3, dtype=int)
     line_breaks = [(line_breaks[n], line_breaks[n+1]) for n in range(len(line_breaks)-1)]
-    
-    start_time = time.time()
-    res = list(workers.map_unordered(lambda a, b: a.run_lines.remote(b), line_breaks))
 
+    start_time = time.time()
+    res        = list(workers.map_unordered(lambda a, b: a.run_lines.remote(b), line_breaks))
     total_time = time.time() - start_time
-    logging.info(f'Analytical line inversions complete.  {round(total_time,2)}s total, {round(rdns[0]*rdns[1]/total_time,4)} spectra/s, '
-                 f'{round(rdns[0]*rdns[1]/total_time/n_workers,4)} spectra/s/core')
+    logging.info(
+        f'Analytical line inversions complete.  {round(total_time,2)}s total, '
+        f'{round(rdns[0]*rdns[1]/total_time,4)} spectra/s, '
+        f'{round(rdns[0]*rdns[1]/total_time/n_workers,4)} spectra/s/core'
+    )
 
 class Worker(object):
-    def __init__(self, config: configs.Config, fm: ForwardModel, RT_state_file: str, 
-                 analytical_state_file: str, analytical_state_unc_file: str, 
-                 rdn_file:str, loc_file:str, obs_file:str, loglevel: str, logfile: str):
+    def __init__(self,
+        config                   : configs.Config,
+        fm                       : ForwardModel,
+        RT_state_file            : str,
+        analytical_state_file    : str,
+        analytical_state_unc_file: str,
+        rdn_file                 : str,
+        loc_file                 : str,
+        obs_file                 : str,
+        loglevel                 : str,
+        logfile                  : str
+    ):
         """
         Worker class to help run a subset of spectra.
 
@@ -168,8 +193,9 @@ class Worker(object):
         self.analytical_state_unc_file = analytical_state_unc_file
 
     def run_lines(self, startstop: tuple):
-
-
+        """
+        TODO: Description
+        """
         rdn = envi.open(envi_header(self.rdn_file)).open_memmap(interleave='bip')
         loc = envi.open(envi_header(self.loc_file)).open_memmap(interleave='bip')
         obs = envi.open(envi_header(self.obs_file)).open_memmap(interleave='bip')
@@ -180,7 +206,6 @@ class Worker(object):
         output_state_unc = np.zeros((stop_line-start_line, rt_state.shape[1], rdn.shape[2])) - 9999
 
         for r in range(start_line, stop_line):
-            
             for c in range(output_state.shape[1]):
                 meas = rdn[r,c,:]
                 x_RT = rt_state[r,c,:]
@@ -196,5 +221,5 @@ class Worker(object):
             write_bil_chunk(output_state_unc[r-start_line,...].T, self.analytical_state_unc_file, r, (rdn.shape[0], rdn.shape[1], rdn.shape[2]))
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/isofit/utils/atm_interpolation.py
+++ b/isofit/utils/atm_interpolation.py
@@ -17,30 +17,40 @@
 # ISOFIT: Imaging Spectrometer Optimal FITting
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 #
-
-from scipy.linalg import inv
-from isofit.core.fileio import write_bil_chunk
-from isofit.core.instrument import Instrument
-from spectral.io import envi
-from scipy.spatial import KDTree
-import numpy as np
-import logging
-import time
-import matplotlib
-import pylab as plt
-from isofit.configs import configs
-import ray
 import atexit
-from isofit.core.common import envi_header
+import logging
+import matplotlib
+import numpy as np
+import pylab as plt
+import ray
+import time
+
+from scipy.linalg  import inv
+from scipy.spatial import KDTree
 from scipy.ndimage import gaussian_filter
+from spectral.io   import envi
 
-plt.switch_backend("Agg")
+from isofit.configs         import configs
+from isofit.core.common     import envi_header
+from isofit.core.fileio     import write_bil_chunk
+from isofit.core.instrument import Instrument
 
+plt.switch_backend('Agg')
 
 @ray.remote
-def _run_chunk(start_line: int, stop_line: int, reference_state_file: str, reference_locations_file: str,
-               input_locations_file: str, segmentation_file: str, output_atm_file: str,
-               nneighbors: int, nodata_value: float, loglevel: str, logfile: str) -> None:
+def _run_chunk(
+    start_line              : int,
+    stop_line               : int,
+    reference_state_file    : str,
+    reference_locations_file: str,
+    input_locations_file    : str,
+    segmentation_file       : str,
+    output_atm_file         : str,
+    nneighbors              : int,
+    nodata_value            : float,
+    loglevel                : str,
+    logfile                 : str
+    ) -> None:
     """
     Args:
         start_line: line to start empirical line run at
@@ -63,34 +73,39 @@ def _run_chunk(start_line: int, stop_line: int, reference_state_file: str, refer
 
     Returns:
         None
-
     """
-
-    logging.basicConfig(format='%(levelname)s:%(asctime)s ||| %(message)s', level=loglevel, filename=logfile, datefmt='%Y-%m-%d,%H:%M:%S')
+    logging.basicConfig(
+        format   = '%(levelname)s:%(asctime)s ||| %(message)s',
+        level    = loglevel,
+        filename = logfile,
+        datefmt  = '%Y-%m-%d,%H:%M:%S'
+    )
 
     # Load reference images
-    reference_state_img = envi.open(envi_header(reference_state_file), reference_state_file)
+    reference_state_img     = envi.open(envi_header(reference_state_file)    , reference_state_file    )
     reference_locations_img = envi.open(envi_header(reference_locations_file), reference_locations_file)
 
-    n_reference_lines, n_state_bands, n_reference_columns = [int(reference_state_img.metadata[n])
-                                                                for n in ('lines', 'bands', 'samples')]
+    n_reference_lines, n_state_bands, n_reference_columns = [
+        int(reference_state_img.metadata[n])
+        for n in ('lines', 'bands', 'samples')
+    ]
 
     # Load input images
     input_locations_img = envi.open(envi_header(input_locations_file), input_locations_file)
-    n_location_bands = int(input_locations_img.metadata['bands'])
-    n_input_samples = input_locations_img.shape[1]
-    n_input_lines = input_locations_img.shape[0]
+    n_location_bands    = int(input_locations_img.metadata['bands'])
+    n_input_samples     = input_locations_img.shape[1]
+    n_input_lines       = input_locations_img.shape[0]
 
     # Load output images
 
     # Load reference data
     reference_locations_mm = reference_locations_img.open_memmap(interleave='bip', writable=False)
-    reference_locations = np.array(reference_locations_mm[:, :, :]).reshape((n_reference_lines, n_location_bands))
+    reference_locations    = np.array(reference_locations_mm[:, :, :]).reshape((n_reference_lines, n_location_bands))
 
-    atm_bands = np.where(np.array([x[:4] != 'RFL_' for x in reference_state_img.metadata['band names']]))[0]
-    n_atm_bands = len(atm_bands)
+    atm_bands          = np.where(np.array([x[:4] != 'RFL_' for x in reference_state_img.metadata['band names']]))[0]
+    n_atm_bands        = len(atm_bands)
     reference_state_mm = reference_state_img.open_memmap(interleave='bip', writable=False)
-    reference_state = np.array(reference_state_mm[:, :, atm_bands]).reshape((n_reference_lines, n_atm_bands))
+    reference_state    = np.array(reference_state_mm[:, :, atm_bands]).reshape((n_reference_lines, n_atm_bands))
 
     # Load segmentation data
     if segmentation_file:
@@ -100,7 +115,7 @@ def _run_chunk(start_line: int, stop_line: int, reference_state_file: str, refer
         segmentation_img = None
 
     # Load Tree
-    loc_scaling = np.array([1e6, 1e6, 0.01])
+    loc_scaling    = np.array([1e6, 1e6, 0.01])
     scaled_ref_loc = reference_locations * loc_scaling
     tree = KDTree(scaled_ref_loc)
     # Assume (heuristically) that, for distance purposes, 1 m vertically is
@@ -110,21 +125,17 @@ def _run_chunk(start_line: int, stop_line: int, reference_state_file: str, refer
 
     # Iterate through image
     hash_table = {}
-
     for row in np.arange(start_line, stop_line):
-
         # Load inline input data
-        input_locations_mm = input_locations_img.open_memmap(
-            interleave='bip', writable=False)
+        input_locations_mm = input_locations_img.open_memmap(interleave='bip', writable=False)
         input_locations = np.array(input_locations_mm[row, :, :])
-
-        output_atm_row = np.zeros((n_input_samples, len(atm_bands))) + nodata_value
-
+        output_atm_row  = np.zeros((n_input_samples, len(atm_bands))) + nodata_value
         nspectra, start = 0, time.time()
-        for col in np.arange(n_input_samples):
 
+        for col in np.arange(n_input_samples):
             x = input_locations[col, :]
-            if np.all(np.isclose(x, nodata_value)):
+
+            if np.isclose(x, nodata_value).all():
                 output_atm_row[col, :] = nodata_value
                 continue
             else:
@@ -166,24 +177,38 @@ def _run_chunk(start_line: int, stop_line: int, reference_state_file: str, refer
             nspectra = nspectra + 1
 
         elapsed = float(time.time() - start)
-        logging.debug('row {}/{}, ({}/{} local), {} spectra per second'.format(row, n_input_lines, int(row - start_line),
-                                                                              int(stop_line - start_line),
-                                                                              round(float(nspectra) / elapsed, 2)))
+        logging.debug('row {}/{}, ({}/{} local), {} spectra per second'.format(
+            row,
+            n_input_lines,
+            int(row - start_line),
+            int(stop_line - start_line),
+            round(float(nspectra) / elapsed, 2)
+        ))
 
         del input_locations_mm
 
         output_atm_row = output_atm_row.transpose((1, 0))
 
-        write_bil_chunk(output_atm_row, output_atm_file, row,
-                         (n_input_lines, n_atm_bands, n_input_samples))
+        write_bil_chunk(
+            output_atm_row,
+            output_atm_file,
+            row,
+            (n_input_lines, n_atm_bands, n_input_samples)
+        )
 
-
-
-def atm_interpolation(reference_state_file: str, 
-                      reference_locations_file: str, segmentation_file: str, 
-                      input_locations_file: str, output_atm_file: str,
-                      nneighbors: int = 400, nodata_value: float = -9999.0, level: str = 'INFO', logfile: str = None,
-                      n_cores: int = -1, gaussian_smoothing_sigma=2) -> None:
+def atm_interpolation(
+    reference_state_file    : str,
+    reference_locations_file: str,
+    segmentation_file       : str,
+    input_locations_file    : str,
+    output_atm_file         : str,
+    nneighbors              : int   = 400,
+    nodata_value            : float = -9999.0,
+    loglevel                : str   = 'INFO',
+    logfile                 : str   = None,
+    n_cores                 : int   = -1,
+    gaussian_smoothing_sigma        = 2
+    ) -> None:
     """
     Perform an empirical line interpolation for reflectance and uncertainty extrapolation
     Args:
@@ -199,7 +224,7 @@ def atm_interpolation(reference_state_file: str,
 
         nneighbors: number of neighbors to use for interpolation
         nodata_value: nodata value of input and output
-        level: logging level
+        loglevel: logging level
         logfile: logging file
         radiance_factors: radiance adjustment factors
         isofit_config: path to isofit configuration JSON file
@@ -208,50 +233,51 @@ def atm_interpolation(reference_state_file: str,
     Returns:
         None
     """
-
-    loglevel = level
-
-    logging.basicConfig(format='%(levelname)s:%(asctime)s ||| %(message)s', level=loglevel, filename=logfile, datefmt='%Y-%m-%d,%H:%M:%S')
+    logging.basicConfig(
+        format   = '%(levelname)s:%(asctime)s ||| %(message)s',
+        level    = loglevel,
+        filename = logfile,
+        datefmt  = '%Y-%m-%d,%H:%M:%S'
+    )
 
     reference_state_img = envi.open(envi_header(reference_state_file))
     input_locations_img = envi.open(envi_header(input_locations_file))
-    n_input_lines = int(input_locations_img.metadata['lines'])
+
+    n_input_lines   = int(input_locations_img.metadata['lines'])
     n_input_samples = int(input_locations_img.metadata['samples'])
 
     # Create output files
     output_metadata = reference_state_img.metadata
     output_metadata['interleave'] = 'bil'
-    output_metadata['lines'] = input_locations_img.metadata['lines']
-    output_metadata['samples'] = input_locations_img.metadata['samples']
+    output_metadata['lines']      = input_locations_img.metadata['lines']
+    output_metadata['samples']    = input_locations_img.metadata['samples']
 
-    band_names = [x for x in reference_state_img.metadata['band names'] if x[:4] != 'RFL_' ]
-    output_metadata['band names'] = band_names
+    band_names = [x for x in reference_state_img.metadata['band names'] if x[:4] != 'RFL_']
+    output_metadata['band names']  = band_names
     output_metadata['description'] = 'Interpolated atmospheric state'
-    output_metadata['bands'] = len(band_names)
+    output_metadata['bands']       = len(band_names)
+
     del output_metadata['fwhm']
     del output_metadata['wavelenth']
 
-    output_atm_img = envi.create_image(envi_header(output_atm_file), ext='',
-                                       metadata=output_metadata, force=True)
+    output_atm_img = envi.create_image(envi_header(output_atm_file), ext='', metadata=output_metadata, force=True)
 
     # Now cleanup inputs and outputs, we'll write dynamically above
-    del output_atm_img
-    del reference_state_img, input_locations_img
+    del output_atm_img, reference_state_img, input_locations_img
 
     # Initialize ray cluster
     start_time = time.time()
-    rayargs = {'ignore_reinit_error': True,
-               'local_mode': n_cores == 1}
-    if n_cores != -1:
-        ray_argw['num_cpus'] = n_cores
+    ray.init(
+        ignore_reinit_error = True,
+        local_mode          = n_cores == 1
+    )
 
-    ray.init(**rayargs)
     atexit.register(ray.shutdown)
 
-    n_ray_cores = int(ray.available_resources()["CPU"])
-    n_cores = min(n_ray_cores, n_input_lines)
+    n_ray_cores = int(ray.available_resources()['CPU'])
+    n_cores     = min(n_ray_cores, n_input_lines)
 
-    logging.info('Beginning atmospheric interpolation {} cores'.format(n_cores))
+    logging.info(f'Beginning atmospheric interpolation {n_cores} cores')
 
     # Break data into sections
     line_sections = np.linspace(0, n_input_lines, num=int(n_cores + 1), dtype=int)
@@ -259,43 +285,39 @@ def atm_interpolation(reference_state_file: str,
     start_time = time.time()
 
     # Run the pool (or run serially)
-    results = []
-    for l in range(len(line_sections) - 1):
-        args = (line_sections[l], line_sections[l + 1], reference_state_file, 
-                reference_locations_file, 
-                input_locations_file, segmentation_file, output_atm_file,
-                nneighbors, nodata_value, level, logfile)
-        results.append(_run_chunk.remote(*args))
-
+    args = (
+        reference_state_file, reference_locations_file,
+        input_locations_file, segmentation_file, output_atm_file,
+        nneighbors, nodata_value, loglevel, logfile
+    )
+    results = [
+        _run_chunk.remote(line_sections[l], line_sections[l + 1], *args)
+        for l in range(len(line_sections) - 1)
+    ]
     _ = ray.get(results)
 
     total_time = time.time() - start_time
     logging.info('Parallel atmospheric interpolations complete.  {} s total, {} spectra/s, {} spectra/s/core'.format(
-        total_time, line_sections[-1] * n_input_samples / total_time,
-                    line_sections[-1] * n_input_samples / total_time / n_cores))
-
+        total_time,
+        line_sections[-1] * n_input_samples / total_time,
+        line_sections[-1] * n_input_samples / total_time / n_cores
+    ))
 
     atm_img = envi.open(envi_header(output_atm_file)).open_memmap(interleave='bip').copy()
 
     if gaussian_smoothing_sigma > 0:
         for n in range(atm_img.shape[-1]):
-            null = atm_img[...,n] == -9999
-            V=atm_img[...,n]
-            V[null]=0
-            VV=gaussian_filter(V,sigma=gaussian_smoothing_sigma)
+            null    = atm_img[...,n] == -9999
+            V       = atm_img[...,n]
+            V[null] = 0
+            VV      = gaussian_filter(V,sigma=gaussian_smoothing_sigma)
 
-            W=0*atm_img[...,n]+1
-            W[null]=0
-            WW=gaussian_filter(W,sigma=gaussian_smoothing_sigma)
+            W       = 0 * atm_img[...,n] + 1
+            W[null] = 0
+            WW      = gaussian_filter(W,sigma=gaussian_smoothing_sigma)
 
-            smoothed=VV/WW
+            smoothed = VV / WW
             atm_img[...,n] = smoothed
 
         atm_img = atm_img.transpose((0,2,1))
         write_bil_chunk(atm_img, output_atm_file, 0, atm_img.shape)
-
-
-
-
-
-


### PR DESCRIPTION
I applied some style changes to the new script in PR https://github.com/isofit/isofit/pull/298
- Reorganized imports
- Aligned some variables to make the code easier on the eyes
- Removed some redundancy
- Simplified the Ray instantiation and worker jobs
- Enforced consistency between single/double quotes, line lengths, and indentation
- Added TODO statements to track further changes not implemented here

Additional comments:
- There are imports in a function scope for [inverse_simple.py#L195-L196](https://github.com/isofit/isofit/blob/920291c8096bf4ac7b74d39c63dca4912efdd7ed/isofit/inversion/inverse_simple.py#L195-L196). Is there a reason these imports are placed in the function rather than at the top of the file? Unless `scipy.linalg` is an optional module that could raise an exception at run time, would it not be better to place these imports at the top along with the rest?
- Style changes were only applied to new files. While it would be ideal to do a style sweep of the repo, this is at least a baby step in ensuring new files entering the repo are consistent. 