### PR TITLE
File Locking Resolution

### DIFF
--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -15,40 +15,32 @@ from netCDF4 import Dataset
 Logger = logging.getLogger(__file__)
 
 
-# Statically store expected keys of the LUT file
+# Statically store expected keys of the LUT file and their fill values
 class Keys:
 
     # Constants, not along any dimension
-    consts = [
-        "coszen",
-        "solzen",
-    ]
+    consts = {
+        "coszen": np.nan,
+        "solzen": np.nan,
+    }
 
     # Along the wavelength dimension only
-    onedim = [
-        "fwhm",
-        "solar_irr",
-    ]
+    onedim = {
+        "fwhm": np.nan,
+        "solar_irr": np.nan,
+    }
 
     # Keys along all dimensions, ie. wl and point
-    alldim = [
-        "rhoatm",
-        "sphalb",
-        "transm_down_dir",
-        "transm_down_dif",
-        "transm_up_dir",
-        "transm_up_dif",
-        "thermal_upwelling",
-        "thermal_downwelling",
-    ]
-
-    # These keys are filled with zeros instead of NaNs
-    zeros = [
-        "transm_down_dir",
-        "transm_down_dif",
-        "transm_up_dir",
-        "transm_up_dif",
-    ]
+    alldim = {
+        "rhoatm": np.nan,
+        "sphalb": np.nan,
+        "transm_down_dir": 0,
+        "transm_down_dif": 0,
+        "transm_up_dir": 0,
+        "transm_up_dif": 0,
+        "thermal_upwelling": np.nan,
+        "thermal_downwelling": np.nan,
+    }
 
 
 class Create:
@@ -94,85 +86,59 @@ class Create:
 
         self.sizes = {key: len(val) for key, val in grid.items()}
 
-        def override(base, addition):
-            out = {}
-            for key in base:
-                if key in addition.keys():
-                    out[key] = addition[key]
-                else:
-                    if key in self.zeros:
-                        out[key] = 0
-                    else:
-                        out[key] = np.nan
-            for key in addition:
-                if key not in out.keys():
-                    out[key] = addition[key]
-            return out
-
-        self.zeros = Keys.zeros + zeros
-        self.consts = override(Keys.consts, consts)
-        self.onedim = override(Keys.onedim, onedim)
-        self.alldim = override(Keys.alldim, alldim)
+        self.consts = {**Keys.consts, **consts}
+        self.onedim = {**Keys.onedim, **onedim}
+        self.alldim = {**Keys.alldim, **alldim}
 
         # Save ds for backwards compatibility (to work with extractGrid, extractPoints)
-        self.ds = self.initialize()
-
-        # Remove variables to reduce memory footprint
-        if reduce:
-            # Drop all variables
-            drop = set(self.ds)
-
-            # Remove these from the drop list
-            if isinstance(reduce, list):
-                drop -= set(reduce)
-
-            self.ds = self.ds.drop_vars(drop)
+        self.initialize()
 
     def initialize(self) -> None:
         """
         Initializes the LUT netCDF by prepopulating it with filler values.
         """
 
-        nc_ds = Dataset(self.file, "w", format="NETCDF4")
-        chunks = []
-        for key, val in self.grid.items():
-            nc_ds.createDimension(key, len(val))
-            chunks.append(1)
-        nc_ds.createDimension("wl", len(self.wl))
-        chunks.insert(0, len(self.wl))
-
-        # Constants
-        for key, fill in self.consts.items():
-            nc_var = nc_ds.createVariable(key, "f8", fill_value=np.nan)
-            nc_var = np.nan
-
-        # One dimensional arrays
-        for key, fill in self.onedim.items():
-            nc_var = nc_ds.createVariable(key, "f8", ("wl",), fill_value=np.nan)
-            nc_var[:] = fill
-
-        # Multi dimensional arrays
-        for key, fill in self.alldim.items():
-            nc_var = nc_ds.createVariable(
-                key,
-                "f8",
-                ("wl",) + tuple(self.grid.keys()),
-                chunksizes=chunks,
-                fill_value=np.nan,
+        def createVariable(key, vals, dims=(), fill_value=np.nan, chunksizes=None):
+            """
+            Reusable createVariable for the Dataset object
+            """
+            var = ds.createVariable(
+                varname=key,
+                datatype="f8",
+                dimensions=dims,
+                fill_value=fill_value,
+                chunksizes=chunksizes,
             )
-            nc_var[:] = fill
+            var[:] = vals
 
-        for key, fill in self.grid.items():
-            nc_var = nc_ds.createVariable(key, "f8", (key,), fill_value=np.nan)
-            nc_var[:] = fill
+        with Dataset(self.file, "w", format="NETCDF4") as ds:
+            # Dimensions
+            ds.createDimension("wl", len(self.wl))
+            createVariable("wl", self.wl, ("wl",))
 
-        nc_ds.sync()
-        nc_ds.close()
-        del nc_ds
+            chunks = [len(self.wl)]
+            for key, vals in self.grid.items():
+                ds.createDimension(key, len(vals))
+                createVariable(key, vals, (key,))
+                chunks.append(1)
+
+            # Constants
+            dims = ()
+            for key, vals in self.consts.items():
+                createVariable(key, vals, dims)
+
+            # One dimensional arrays
+            dims = ("wl",)
+            for key, vals in self.onedim.items():
+                createVariable(key, vals, dims)
+
+            # Multi dimensional arrays
+            dims += tuple(self.grid)
+            for key, vals in self.alldim.items():
+                createVariable(key, vals, dims, chunksizes=chunks)
+
+            ds.sync()
         gc.collect()
-        ds = xr.open_dataset(self.file, mode="r")
-        # Create the point dimension
-        return ds.stack(point=self.grid).transpose("point", "wl")
 
     def pointIndices(self, point: np.ndarray) -> List[int]:
         """
@@ -210,25 +176,29 @@ class Create:
         """
         Flushes the (point, data) pairs held in the hold list to the LUT netCDF.
         """
-        ds = Dataset(self.file, "a")
-        for point, data in self.hold:
-            for key, vals in data.items():
-                if key in self.consts:
-                    ds[key].assignValue(vals)
-                elif key in self.onedim:
-                    ds[key][:] = vals
-                elif key in self.alldim:
-                    index = [slice(None)] + list(self.pointIndices(point))
-                    ds[key][index] = vals
-                else:
-                    Logger.warning(
-                        f"Attempted to assign a key that is not recognized, skipping: {key}"
-                    )
-        ds.sync()
-        ds.close()
-        del ds
-        gc.collect()
+        unknowns = set()
+        with Dataset(self.file, "a") as ds:
+            for point, data in self.hold:
+                pointIndex = [slice(None)] + list(self.pointIndices(point))
+                for key, vals in data.items():
+                    if key in self.consts:
+                        ds[key].assignValue(vals)
+                    elif key in self.onedim:
+                        ds[key][:] = vals
+                    elif key in self.alldim:
+                        ds[key][pointIndex] = vals
+                    else:
+                        unknowns.update([key])
+            ds.sync()
+
         self.hold = []
+        gc.collect()
+
+        # Reduce the number of warnings produced per flush
+        for key in unknowns:
+            Logger.warning(
+                f"Attempted to assign a key that is not recognized, skipping: {key}"
+            )
 
     def writePoint(self, point: np.ndarray, data: dict) -> None:
         """

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -179,14 +179,14 @@ class Create:
         unknowns = set()
         with Dataset(self.file, "a") as ds:
             for point, data in self.hold:
-                pointIndex = [slice(None)] + list(self.pointIndices(point))
                 for key, vals in data.items():
                     if key in self.consts:
                         ds[key].assignValue(vals)
                     elif key in self.onedim:
                         ds[key][:] = vals
                     elif key in self.alldim:
-                        ds[key][pointIndex] = vals
+                        index = [slice(None)] + list(self.pointIndices(point))
+                        ds[key][index] = vals
                     else:
                         unknowns.update([key])
             ds.sync()

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -55,6 +55,8 @@ class FileExistsError(Exception):
 class ModtranRT(RadiativeTransferEngine):
     """A model of photon transport including the atmosphere."""
 
+    max_buffer_time = 0.5
+
     @staticmethod
     def parseTokens(tokens: list, coszen: float) -> dict:
         """

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -44,6 +44,10 @@ class RadiativeTransferEngine:
     # Allows engines to outright disable the parallelized sims if they do nothing
     _disable_makeSim = False
 
+    # Sleep a random amount of time up to max this value at the start of each streamSimulation
+    # Can be set per custom engine
+    max_buffer_time = 0
+
     # These are retrieved from the geom object
     geometry_input_names = [
         "observer_azimuth",
@@ -73,8 +77,6 @@ class RadiativeTransferEngine:
     )
 
     # These properties enable easy access to the lut data
-    wl = property(lambda self: np.array(self["wl"]))
-    fwhm = property(lambda self: np.array(self["fwhm"]))
     coszen = property(lambda self: self["coszen"])
     solar_irr = property(lambda self: self["solar_irr"])
 
@@ -137,6 +139,10 @@ class RadiativeTransferEngine:
                 except:
                     pass
 
+        # Set for downstream engines may use
+        self.wl = wl
+        self.fwhm = fwhm
+
         # ToDo: move setting of multipart rfl values to config
         if self.multipart_transmittance:
             self.test_rfls = [0.1, 0.5]
@@ -152,13 +158,13 @@ class RadiativeTransferEngine:
             self.points, self.lut_names = luts.extractPoints(self.lut)
 
             # if necessary, resample prebuilt LUT to desired instrument spectral response
-            if not all(wl == self.wl):
+            if not all(wl == self.lut.wl):
                 conv = xr.Dataset(coords={"wl": wl, "point": self.lut.point})
                 for quantity in self.lut:
                     conv[quantity] = (
                         ("wl", "point"),
                         common.resample_spectrum(
-                            self.lut[quantity].data, self.wl, wl, fwhm
+                            self.lut[quantity].data, self.lut.wl, wl, fwhm
                         ),
                     )
                 self.lut = conv
@@ -184,7 +190,7 @@ class RadiativeTransferEngine:
                 file=self.lut_path,
                 wl=wl,
                 grid=self.lut_grid,
-                onedim={"fwhm": fwhm, "wl": wl},
+                onedim={"fwhm": fwhm},
             )
 
             # Create and populate a LUT file
@@ -398,9 +404,8 @@ class RadiativeTransferEngine:
             makeSim = ray.put(self.makeSim)
             readSim = ray.put(self.readSim)
             lut_path = ray.put(self.lut_path)
-            buffer_time = 0
-            if self.engine_config.name == "modtran":
-                buffer_time = 0.5
+            buffer_time = ray.put(self.max_buffer_time)
+
             jobs = [
                 streamSimulation.remote(
                     point,
@@ -436,7 +441,8 @@ class RadiativeTransferEngine:
                 if report(len(jobs)):
                     Logger.info("Flushing netCDF to disk")
                     self.lut.flush()
-            del lut_names, makeSim, readSim, lut_path
+
+            del lut_names, makeSim, readSim, lut_path, buffer_time
 
             # Shouldn't be hit but just in case
             if self.lut.hold:


### PR DESCRIPTION
Few tweaks to your current PR:

- Resolved the file locking issues
  - Removed RTE's dependency on accessing `wl` and `fwhm` from `self.lut` (the `xr.Dataset`)
- A few design tweaks, open for discussion:
  - Moved `max_buffer_time` to be a class-level parameter set by each RTE rather than hardcoded specifically for modtran to allow
  - Changed `Create.initialize` to share a `createVariable` function so it is clearer what is happening for each variable being inserted and is consistent between `consts`, `onedim`, and `alldim`
  - Replaced your `override` function in `Create.__init__` by changing the types of `Keys` to be dicts with values as the fill value for each key. This can be overridden using the input parameters to the `__init__`
    - Removes the need to pass `wl` into the `onedim` override
    - Removes the `zeros` list and makes it clear what the default fill value for each key is
- Changed `flush` to cache unknown keys and report them at the end instead of per point to reduce total number of warnings if a bad key is provided

I don't intend to step on any toes so I'm open to discussing these changes and/or just cherry-picking the pieces you actually need. From local testing I was seeing identical performance and outputs to ensure consistency. 

At minimum, I would recommend taking:
- The changes to `luts.Keys`
  - Needs the changes to `luts.Create.__init__` as well
- The changes to `radiative_transfer_engine.py`
  - Needs the changes to `modtran.py` as well