### PR TITLE
LUT Resampling

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -624,35 +624,39 @@ def resample_spectrum(
         np.array: interpolated radiance vector
 
     """
-    # check if x is vector or matrix
-    if len(x.shape) > 1:
-        x_raw = x.copy()
-        x_raw = x_raw.transpose()
-    else:
-        x_raw = x.copy()
-        x_raw = x_raw.reshape((len(x), 1))
-
     H = np.array(
         [
             spectral_response_function(wl, wi, fwhmi / 2.355)
             for wi, fwhmi in zip(wl2, fwhm2)
         ]
     )
+    H[np.isnan(H)] = 0
 
-    if fill is False:
-        if len(x.shape) > 1:
-            return np.array([np.nansum(H * y[np.newaxis, :], axis=1) for y in x])
-            # return np.dot(H, x_raw).transpose()
-        else:
-            return np.dot(H, x_raw).ravel()
-    else:
-        xnew = np.dot(H, x_raw).ravel()
+    shape = len(x.shape)
+    if fill:
+        if shape > 1:
+            raise Exception("resample_spectrum(fill=True) only works with vectors")
+
+        x = x.reshape(-1, 1)
+        xnew = np.dot(H, x).ravel()
         good = np.isfinite(xnew)
         for i, xi in enumerate(xnew):
             if not good[i]:
                 nearest_good_ind = np.argmin(abs(wl2[good] - wl2[i]))
                 xnew[i] = xnew[nearest_good_ind]
         return xnew
+    else:
+        # Replace NaNs with zeros
+        x[np.isnan(x)] = 0
+
+        # Matrix
+        if shape > 1:
+            return np.dot(H, x.T).T
+
+        # Vector
+        else:
+            x = x.reshape(-1, 1)
+            return np.dot(H, x).ravel()
 
 
 def load_spectrum(spectrum_file: str) -> (np.array, np.array):

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -330,7 +330,7 @@ def sub(ds: xr.Dataset, dim: str, strat) -> xr.Dataset:
 
 
 def load(
-    file: str, subset: dict = None, dask=True, mode="r", lock=False, **kwargs
+    file: str, subset: dict = None, dask=True, mode="r", lock=False, load=True, **kwargs
 ) -> xr.Dataset:
     """
     Loads a LUT NetCDF
@@ -347,6 +347,9 @@ def load(
     dask: bool, default=True
         Use Dask on the backend of Xarray to lazy load the dataset. This enables
         out-of-core subsetting
+    load: bool, default=True
+        Calls ds.load() at the end to cast from Dask arrays back into numpy arrays held
+        in memory
 
     Examples
     --------
@@ -542,6 +545,10 @@ def load(
             Logger.warning(
                 f"Detected NaNs in the following LUT variable and may cause issues: {name}"
             )
+
+    if load:
+        Logger.info("Loading LUT into memory")
+        ds.load()
 
     return ds
 

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -175,34 +175,30 @@ class RadiativeTransferEngine:
                     "Unknown RT mode provided in LUT file. Please use either 'transm' or 'rdn'."
                 )
 
-            # if necessary, resample prebuilt LUT to desired instrument spectral response
-            if not len(wl) == len(self.lut.wl) or all(wl == self.lut.wl):
-                conv = xr.Dataset(
-                    coords={"point": self.lut.point, "wl": wl},
-                    attrs={"RT_mode": self.rt_mode},
+            # If necessary, resample prebuilt LUT to desired instrument spectral response
+            if not len(wl) == len(self.lut.wl) or not all(wl == self.lut.wl):
+                # Discover variables along the wl dim
+                keys = {key for key, data in self.lut.items() if "wl" in data.dims}
+
+                # Apply resampling to these keys
+                conv = xr.apply_ufunc(
+                    common.resample_spectrum,
+                    self.lut[keys],
+                    kwargs={"wl": self.lut.wl, "wl2": outWL, "fwhm2": outWL},
+                    input_core_dims=[["wl"]],  # Only operate on keys with this dim
+                    exclude_dims={
+                        "wl",
+                    },  # Allows changing the wl size
+                    output_core_dims=[["wl"]],  # Adds wl to the expected output dims
+                    keep_attrs="override",
+                    # on_missing_core_dim = 'copy' # Newer versions of xarray support this
                 )
-                for quantity in self.lut:
-                    if quantity in luts.Keys.alldim.keys():
-                        conv[quantity] = (
-                            ("point", "wl"),
-                            common.resample_spectrum(
-                                self.lut[quantity].data, self.lut.wl, wl, fwhm
-                            ),
-                        )
-                    if quantity == "solar_irr":
-                        conv[quantity] = (
-                            "wl",
-                            common.resample_spectrum(
-                                self.lut[quantity].data, self.lut.wl, wl, fwhm
-                            ),
-                        )
-                    if quantity == "fwhm":
-                        conv[quantity] = ("wl", fwhm)
-                    if quantity in luts.Keys.consts.keys():
-                        conv[quantity] = self.lut[quantity].data
+                # If not on newer versions
+                for key in list(self.lut.drop_dims("wl")):
+                    conv[key] = self.lut[key]
 
+                # Exchange the lut with the resampled version
                 self.lut = conv
-
         else:
             Logger.info(f"No LUT store found, beginning initialization and simulations")
             # Check if both wavelengths and fwhm are provided for building the LUT

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -184,16 +184,20 @@ class RadiativeTransferEngine:
                 conv = xr.apply_ufunc(
                     common.resample_spectrum,
                     self.lut[keys],
-                    kwargs={"wl": self.lut.wl, "wl2": outWL, "fwhm2": outWL},
+                    kwargs={"wl": self.lut.wl, "wl2": wl, "fwhm2": fwhm},
                     input_core_dims=[["wl"]],  # Only operate on keys with this dim
                     exclude_dims=set(["wl"]),  # Allows changing the wl size
                     output_core_dims=[["wl"]],  # Adds wl to the expected output dims
                     keep_attrs="override",
                     # on_missing_core_dim = 'copy' # Newer versions of xarray support this
                 )
+
                 # If not on newer versions
                 for key in list(self.lut.drop_dims("wl")):
                     conv[key] = self.lut[key]
+
+                # Override the fwhm
+                conv["fwhm"] = ("wl", fwhm)
 
                 # Exchange the lut with the resampled version
                 self.lut = conv

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -186,9 +186,7 @@ class RadiativeTransferEngine:
                     self.lut[keys],
                     kwargs={"wl": self.lut.wl, "wl2": outWL, "fwhm2": outWL},
                     input_core_dims=[["wl"]],  # Only operate on keys with this dim
-                    exclude_dims={
-                        "wl",
-                    },  # Allows changing the wl size
+                    exclude_dims=set(["wl"]),  # Allows changing the wl size
                     output_core_dims=[["wl"]],  # Adds wl to the expected output dims
                     keep_attrs="override",
                     # on_missing_core_dim = 'copy' # Newer versions of xarray support this


### PR DESCRIPTION
This PR reworks the LUT resampling code to leverage xarray's `apply_ufunc`. The variables along the `wl` dim are auto-discovered instead of being hardcoded now as well.

# Changes
- Refactored LUT resampling to use xarray.apply_ufunc
- Moved the logic of `core.common:resample_spectrum` around and simplified it + added comments for easier understanding in the future
  - Simplification includes removing the copying of the x array
- Added `load` param to `luts:load()` to auto call `ds.load()` at the end of the function to bring the lut into memory(numpy arrays) instead of returning dask arrays