### PR TITLE
sRTMnet post-sim write attr

### DIFF
--- a/isofit/radiative_transfer/engines/sRTMnet.py
+++ b/isofit/radiative_transfer/engines/sRTMnet.py
@@ -238,6 +238,7 @@ class SimulatedModtranRT(RadiativeTransferEngine):
         # Update engine to run in RDN mode
         self.rt_mode = "rdn"
         # self.lut["RT_mode"] = "rdn"
+        self.lut.setAttr("RT_mode", "rdn")
 
     def get_L_atm(self, x_RT, geom):
         r = self.get(x_RT, geom)

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -227,6 +227,21 @@ class Create:
         self.queuePoint(point, data)
         self.flush()
 
+    def setAttr(self, key, value):
+        """
+        Sets an attribute in the netCDF
+
+        Parameters
+        ----------
+        key : str
+            Key to set
+        value : any
+            Value to set
+        """
+        self.attrs[key] = value
+        with Dataset(self.file, "a") as ds:
+            ds.setncattr(key, value)
+
     def __getitem__(self, key: str) -> Any:
         """
         Passthrough to __getitem__ on the underlying 'ds' attribute.


### PR DESCRIPTION
```python
  File "/store/jamesmo/isofit/repos/pgbrodrick/isofit/radiative_transfer/radiative_transfer_engine.py", line 251, in __init__
    self.runSimulations()
  File "/store/jamesmo/isofit/repos/pgbrodrick/isofit/radiative_transfer/radiative_transfer_engine.py", line 531, in runSimulations
    post = self.postSim()
           ^^^^^^^^^^^^^^
  File "/store/jamesmo/isofit/repos/pgbrodrick/isofit/radiative_transfer/engines/sRTMnet.py", line 240, in postSim
    self.lut["RT_mode"] = "rdn"
    ~~~~~~~~^^^^^^^^^^^
TypeError: 'Create' object does not support item assignment
```
The above is because the simulation functions are using the `luts.py:Create` object when initializing the LUT file. That object could set attributes on initialization but not after. This PR just adds a basic function to enable setting attributes easily.