### PR TITLE
Core/numbagrid

### DIFF
--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -373,7 +373,7 @@ class RadiativeTransferConfig(BaseConfigSection):
         self.unknowns: RadiativeTransferUnknownsConfig = None
 
         self._interpolator_style_type = str
-        self.interpolator_style = "mlg"
+        self.interpolator_style = "mlg_numba"
         """str: Style of interpolation.
         - mlg   = Multilinear Grid
         - rg    = RegularGrid
@@ -442,7 +442,12 @@ class RadiativeTransferConfig(BaseConfigSection):
         for rte in self.radiative_transfer_engines:
             errors.extend(rte.check_config_validity())
 
-        kinds = ["rg", "nds", "mlg"]  # Implemented kinds of interpolator functions
+        kinds = [
+            "rg",
+            "nds",
+            "mlg",
+            "mlg_numba",
+        ]  # Implemented kinds of interpolator functions
         kind = self.interpolator_style[:3]
         degrees = self.interpolator_style[4:]
 

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -30,6 +30,7 @@ import numpy as np
 # sc Adding in xarray for non-gauss SRF file io
 import xarray as xr
 import xxhash
+from numba import float64, int32, njit
 from scipy.interpolate import RegularGridInterpolator
 
 from isofit.core import units
@@ -41,6 +42,105 @@ eps = 1e-5
 Cache = {"stats": {}}
 
 
+@njit(inline="always")
+def fast_searchsorted(array, target):
+    """
+    Numba-optimized binary search to find the insertion index of a target value.
+    Same as np.searchsorted(...,side='left'), but opptimized
+
+    Args:
+        array: 1D array of floats, representing a sorted grid dimension (must be
+               monotonically increasing)
+        target: float value to locate within the grid dimension
+
+    Returns:
+        low: integer index indicating the first element greater than or equal
+             to the target.
+    """
+    low = 0
+    high = len(array) - 1
+    while low < high:
+        mid = (low + high) // 2
+        if array[mid] < target:
+            low = mid + 1
+        else:
+            high = mid
+    return low
+
+
+@njit(cache=True)
+def _numba_mlg_kernel(point, grid_tuples, data):
+    """
+    Numba-accelerated n-dimensional multilinear interpolator kernel. Performs
+    linear interpolation across a multi-dimensional look-up table for a single
+    point, outputting a vector of values.
+
+    Args:
+        point: 1D array of floats, representing the coordinate to interpolate
+               within the n-dimensional grid.
+        grid_tuples: Tuple of 1D arrays of floats, where each array defines the
+                     sorted grid points for a single dimension.
+        data: N+1 dimensional array of floats, where the first N dimensions
+              correspond to grid_tuples and the last dimension contains the
+              output vector (channels).
+
+    Returns:
+        result: 1D array of floats, the interpolated output vector of length
+                equal to data.shape[-1].
+    """
+    dims = len(point)
+    low_indices = np.zeros(dims, dtype=int32)
+    deltas = np.zeros(dims, dtype=float64)
+
+    for i in range(dims):
+        grid = grid_tuples[i]
+        p = point[i]
+
+        # Clamp to grid bounds
+        if p <= grid[0]:
+            low_indices[i] = 0
+            deltas[i] = 0.0
+        elif p >= grid[-1]:
+            low_indices[i] = len(grid) - 2
+            deltas[i] = 1.0
+        else:
+            idx = fast_searchsorted(grid, p) - 1
+            if idx < 0:
+                idx = 0
+            low_indices[i] = idx
+            deltas[i] = (p - grid[idx]) / (grid[idx + 1] - grid[idx])
+
+    num_channels = data.shape[-1]
+    num_corners = 1 << dims
+    result = np.zeros(num_channels)
+
+    # Manual stride calculation for flat indexing
+    strides = np.zeros(dims + 1, dtype=int32)
+    current_stride = 1
+    for i in range(dims, -1, -1):
+        strides[i] = current_stride
+        current_stride *= data.shape[i]
+
+    flat_data = data.ravel()
+
+    for c in range(num_corners):
+        weight = 1.0
+        flat_idx = 0
+        for d in range(dims):
+            if (c >> d) & 1:
+                weight *= deltas[d]
+                flat_idx += (low_indices[d] + 1) * strides[d]
+            else:
+                weight *= 1.0 - deltas[d]
+                flat_idx += low_indices[d] * strides[d]
+
+        start = flat_idx
+        end = start + num_channels
+        result += flat_data[start:end] * weight
+
+    return result
+
+
 class VectorInterpolator:
     """Linear look up table interpolator.  Support linear interpolation through radial space by expanding the look
     up tables with sin and cos dimensions.
@@ -49,14 +149,15 @@ class VectorInterpolator:
         grid_input: list of lists of floats, indicating the gridpoint elements in each grid dimension
         data_input: n dimensional array of radiative transfer engine outputs (each dimension size corresponds to the
                     given grid_input list length, with the last dimensions equal to the number of sensor channels)
-        version: version to use: 'rg' for scipy RegularGridInterpolator, 'mlg' for multilinear grid interpolator
+        version: version to use: 'rg' for scipy RegularGridInterpolator, 'mlg' for multilinear grid interpolator,
+                 'mlg_numba' for numba-accelerated multilinear grid interpolator
     """
 
     def __init__(
         self,
         grid_input: List[List[float]],
         data_input: np.array,
-        version="mlg",
+        version="mlg_numba",
     ):
         # Determine if this a singular unique value, if so just return that directly
         val = data_input[(0,) * data_input.ndim]
@@ -97,6 +198,19 @@ class VectorInterpolator:
                 t[1:] - t[:-1] for t in self.gridtuples
             ]  # binwidth arrays for each dimension
             self.maxbaseinds = np.array([len(t) - 1 for t in self.gridtuples])
+
+        elif version == "mlg_numba":
+            self.method = 3
+            # Need to keep types picklable...better performance with numba lists,
+            # but it doesn't play nicely with ray.
+            self.grid_tuples = tuple(
+                [np.array(g, dtype=np.float64) for g in grid_input]
+            )
+            self.gridarrays = data_input.astype(np.float64)
+
+            # run a warm-up for numba
+            dummy_point = np.array([g[0] for g in self.grid_tuples], dtype=np.float64)
+            _ = _numba_mlg_kernel(dummy_point, self.grid_tuples, self.gridarrays)
 
         else:
             raise AttributeError(f"Unknown interpolator version: {version!r}")
@@ -197,6 +311,8 @@ class VectorInterpolator:
             return self._interpolate(*args, **kwargs)
         elif self.method == 2:
             return self._multilinear_grid(*args, **kwargs)
+        if self.method == 3:
+            return _numba_mlg_kernel(args[0], self.grid_tuples, self.gridarrays)
 
 
 def load_wavelen(wavelength_file: str):

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -235,8 +235,8 @@ class VectorInterpolator:
             _ = self._numba_mlg_kernel(*self._numba_slice_kernel(dummy_point))
 
         elif version == "mlg-cache":
-            self.cache_size = 0
-            self.grid_cache_size = 60
+            self.cache_size = 1
+            self.grid_cache_size = 1000
             self.GridCache = {}
 
             self.gridtuples = [np.array(t) for t in grid]
@@ -367,7 +367,7 @@ class VectorInterpolator:
             return self.GridCache[hash_ar(points[self.cachei])]
 
         else:
-            stats["miss"] += 1
+            self.GridCache["stats"]["miss"] += 1
             if self.grid_cache_size and len(self.GridCache) >= self.grid_cache_size + 1:
                 self.GridCache.pop(list(self.GridCache)[0])
 

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -21,7 +21,9 @@
 import json
 import os
 from collections import OrderedDict
+from datetime import datetime as dtt
 from difflib import SequenceMatcher
+from functools import partial
 from os.path import expandvars
 from typing import List
 
@@ -40,6 +42,10 @@ eps = 1e-5
 
 # Global variable makes it non-shared mem in ray
 Cache = {"stats": {}}
+
+
+def hash_ar(ar):
+    return xxhash.xxh64(ar.tobytes()).intdigest()
 
 
 @njit(inline="always")
@@ -69,25 +75,7 @@ def fast_searchsorted(array, target):
 
 
 @njit(cache=True)
-def _numba_mlg_kernel(point, grid_tuples, flat_data, strides, nchannels):
-    """
-    Numba-accelerated n-dimensional multilinear interpolator kernel. Performs
-    linear interpolation across a multi-dimensional look-up table for a single
-    point, outputting a vector of values.
-
-    Args:
-        point: 1D array of floats, representing the coordinate to interpolate
-               within the n-dimensional grid.
-        grid_tuples: Tuple of 1D arrays of floats, where each array defines the
-                     sorted grid points for a single dimension.
-        data: N+1 dimensional array of floats, where the first N dimensions
-              correspond to grid_tuples and the last dimension contains the
-              output vector (channels).
-
-    Returns:
-        result: 1D array of floats, the interpolated output vector of length
-                equal to data.shape[-1].
-    """
+def _numba_slice_kernel(point, grid_tuples):
     dims = len(point)
     low_indices = np.zeros(dims, dtype=int32)
     deltas = np.zeros(dims, dtype=float64)
@@ -110,6 +98,29 @@ def _numba_mlg_kernel(point, grid_tuples, flat_data, strides, nchannels):
             low_indices[i] = idx
             deltas[i] = (p - grid[idx]) / (grid[idx + 1] - grid[idx])
 
+    return low_indices, deltas, dims
+
+
+@njit(cache=True)
+def _numba_mlg_kernel(low_indices, deltas, dims, flat_data, strides, nchannels):
+    """
+    Numba-accelerated n-dimensional multilinear interpolator kernel. Performs
+    linear interpolation across a multi-dimensional look-up table for a single
+    point, outputting a vector of values.
+
+    Args:
+        point: 1D array of floats, representing the coordinate to interpolate
+               within the n-dimensional grid.
+        grid_tuples: Tuple of 1D arrays of floats, where each array defines the
+                     sorted grid points for a single dimension.
+        data: N+1 dimensional array of floats, where the first N dimensions
+              correspond to grid_tuples and the last dimension contains the
+              output vector (channels)
+
+    Returns:
+        result: 1D array of floats, the interpolated output vector of length
+                equal to data.shape[-1].
+    """
     num_corners = 1 << dims
     result = np.zeros(nchannels)
 
@@ -149,6 +160,7 @@ class VectorInterpolator:
         data_input: np.array,
         version="mlg_numba",
     ):
+        print(version)
         # Determine if this a singular unique value, if so just return that directly
         val = data_input[(0,) * data_input.ndim]
         if np.isnan(val) and np.isnan(data_input).all() or np.all(data_input == val):
@@ -180,7 +192,7 @@ class VectorInterpolator:
             self.method = 2
 
             # None to disable, 0 for unlimited, negatives == 1
-            self.cache_size = 1
+            self.cache_size = 0
 
             self.gridtuples = [np.array(t) for t in grid]
             self.gridarrays = data
@@ -205,18 +217,39 @@ class VectorInterpolator:
             strides[-1] = 1
             for d in range(len(data_shape) - 2, -1, -1):
                 strides[d] = strides[d + 1] * data_shape[d + 1]
+
             self.strides = np.ascontiguousarray(strides, dtype=np.intp)
 
             # run a warm-up for numba
             dummy_point = np.array([g[0] for g in self.grid_tuples], dtype=np.float64)
-            _ = _numba_mlg_kernel(
-                dummy_point,
-                self.grid_tuples,
-                self.flat_data,
-                self.strides,
-                self.nchannels,
+            self._numba_slice_kernel = partial(
+                _numba_slice_kernel, grid_tuples=self.grid_tuples
+            )
+            self._numba_mlg_kernel = partial(
+                _numba_mlg_kernel,
+                flat_data=self.flat_data,
+                strides=self.strides,
+                nchannels=self.nchannels,
             )
 
+            _ = self._numba_mlg_kernel(*self._numba_slice_kernel(dummy_point))
+
+        elif version == "mlg-cache":
+            self.cache_size = 0
+            self.grid_cache_size = 60
+            self.GridCache = {}
+
+            self.gridtuples = [np.array(t) for t in grid]
+            self.gridarrays = data
+            self.binwidth = [
+                t[1:] - t[:-1] for t in self.gridtuples
+            ]  # binwidth arrays for each dimension
+            self.maxbaseinds = np.array([len(t) - 1 for t in self.gridtuples])
+
+            self.method = 4
+            self.cachei = list(range(len(self.gridtuples)))
+
+            # None to disable, 0 for unlimited, negatives == 1
         else:
             raise AttributeError(f"Unknown interpolator version: {version!r}")
 
@@ -258,17 +291,7 @@ class VectorInterpolator:
             delta = (point - self.gridtuples[i][j]) / self.binwidth[i][j]
             return delta, slice(lower(), upper())
 
-    def _multilinear_grid(self, points):
-        """
-        Cached version of Jouni's implementation
-
-        Args:
-            points: The point being interpolated. If at the limit, the extremal value in
-                    the grid is returned.
-
-        Returns:
-            cube: np.ndarray
-        """
+    def _slice(self, points):
         deltas = [None] * points.size
         idxs = [None] * points.size
 
@@ -293,6 +316,21 @@ class VectorInterpolator:
 
             deltas[i], idxs[i] = data
 
+        return deltas, idxs
+
+    def _multilinear_grid(self, points):
+        """
+        Cached version of Jouni's implementation
+
+        Args:
+            points: The point being interpolated. If at the limit, the extremal value in
+                    the grid is returned.
+
+        Returns:
+            cube: np.ndarray
+        """
+        deltas, idxs = self._slice(points)
+
         cube = np.copy(self.gridarrays[tuple(idxs)], order="A")
 
         # Only linear interpolate sliced dimensions
@@ -305,6 +343,40 @@ class VectorInterpolator:
 
         return cube
 
+    @staticmethod
+    def _mlg_kernel(cube, interpi, idxs, deltas):
+        # Only linear interpolate sliced dimensions
+        for i in interpi:
+            idx = idxs[i]
+            delta = deltas[i]
+            if isinstance(idx, slice):
+                cube[0] *= 1 - delta
+                cube[1] *= delta
+                cube[0] += cube[1]
+                cube = cube[0]
+
+        return cube
+
+    def _mlg_grid_cache(self, points):
+        deltas, idxs = self._slice(points)
+        stats = self.GridCache.setdefault("stats", {"hit": 0, "miss": 0})
+
+        if hash_ar(points[self.cachei]) in self.GridCache:
+            self.GridCache["stats"]["hit"] += 1
+
+            return self.GridCache[hash_ar(points[self.cachei])]
+
+        else:
+            stats["miss"] += 1
+            if self.grid_cache_size and len(self.GridCache) >= self.grid_cache_size + 1:
+                self.GridCache.pop(list(self.GridCache)[0])
+
+            cube = np.copy(self.gridarrays[tuple(idxs)], order="A")
+            cube = self._mlg_kernel(cube, self.cachei, idxs, deltas)
+            self.GridCache[hash_ar(points[self.cachei])] = cube
+
+            return cube
+
     def __call__(self, *args, **kwargs):
         """
         Passes args to the appropriate interpolation method defined by the version at
@@ -316,10 +388,10 @@ class VectorInterpolator:
             return self._interpolate(*args, **kwargs)
         elif self.method == 2:
             return self._multilinear_grid(*args, **kwargs)
-        if self.method == 3:
-            return _numba_mlg_kernel(
-                args[0], self.grid_tuples, self.flat_data, self.strides, self.nchannels
-            )
+        elif self.method == 3:
+            return self._numba_mlg_kernel(*self._numba_slice_kernel(*args, **kwargs))
+        elif self.method == 4:
+            return self._mlg_grid_cache(*args, **kwargs)
 
 
 def load_wavelen(wavelength_file: str):
@@ -425,7 +497,7 @@ def svd_inv_sqrt(
     # Default to using numpy eigh (which uses LAPACK evd driver by default).
     try:
         D, P = np.linalg.eigh(C)
-    except:
+    except Exception:
         D, P = None, None
 
     # Sanity check for edge cases that we encounter with negative eigen values, and we offset by inv_eps.
@@ -437,7 +509,7 @@ def svd_inv_sqrt(
                 D, P = np.linalg.eigh(C + np.eye(C.shape[0]) * inv_eps)
                 if not (np.any(D < 0) or np.any(np.isnan(D))):
                     break
-            except:
+            except Exception:
                 continue
         else:
             raise ValueError(
@@ -889,9 +961,6 @@ def ray_start(num_cores, num_cpus=2, memory_b=-1):
         base_args.append(address)
 
         result = subprocess.run(base_args, capture_output=True)
-
-
-from datetime import datetime as dtt
 
 
 class Track:

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -69,7 +69,7 @@ def fast_searchsorted(array, target):
 
 
 @njit(cache=True)
-def _numba_mlg_kernel(point, grid_tuples, data):
+def _numba_mlg_kernel(point, grid_tuples, flat_data, strides, nchannels):
     """
     Numba-accelerated n-dimensional multilinear interpolator kernel. Performs
     linear interpolation across a multi-dimensional look-up table for a single
@@ -110,18 +110,8 @@ def _numba_mlg_kernel(point, grid_tuples, data):
             low_indices[i] = idx
             deltas[i] = (p - grid[idx]) / (grid[idx + 1] - grid[idx])
 
-    num_channels = data.shape[-1]
     num_corners = 1 << dims
-    result = np.zeros(num_channels)
-
-    # Manual stride calculation for flat indexing
-    strides = np.zeros(dims + 1, dtype=int32)
-    current_stride = 1
-    for i in range(dims, -1, -1):
-        strides[i] = current_stride
-        current_stride *= data.shape[i]
-
-    flat_data = data.ravel()
+    result = np.zeros(nchannels)
 
     for c in range(num_corners):
         weight = 1.0
@@ -135,7 +125,7 @@ def _numba_mlg_kernel(point, grid_tuples, data):
                 flat_idx += low_indices[d] * strides[d]
 
         start = flat_idx
-        end = start + num_channels
+        end = start + nchannels
         result += flat_data[start:end] * weight
 
     return result
@@ -207,10 +197,25 @@ class VectorInterpolator:
                 [np.array(g, dtype=np.float64) for g in grid_input]
             )
             self.gridarrays = data_input.astype(np.float64)
+            self.flat_data = self.gridarrays.ravel()
+
+            data_shape = self.gridarrays.shape
+            self.nchannels = data_shape[-1]
+            strides = np.empty(len(data_shape), dtype=np.intp)
+            strides[-1] = 1
+            for d in range(len(data_shape) - 2, -1, -1):
+                strides[d] = strides[d + 1] * data_shape[d + 1]
+            self.strides = np.ascontiguousarray(strides, dtype=np.intp)
 
             # run a warm-up for numba
             dummy_point = np.array([g[0] for g in self.grid_tuples], dtype=np.float64)
-            _ = _numba_mlg_kernel(dummy_point, self.grid_tuples, self.gridarrays)
+            _ = _numba_mlg_kernel(
+                dummy_point,
+                self.grid_tuples,
+                self.flat_data,
+                self.strides,
+                self.nchannels,
+            )
 
         else:
             raise AttributeError(f"Unknown interpolator version: {version!r}")
@@ -312,7 +317,9 @@ class VectorInterpolator:
         elif self.method == 2:
             return self._multilinear_grid(*args, **kwargs)
         if self.method == 3:
-            return _numba_mlg_kernel(args[0], self.grid_tuples, self.gridarrays)
+            return _numba_mlg_kernel(
+                args[0], self.grid_tuples, self.flat_data, self.strides, self.nchannels
+            )
 
 
 def load_wavelen(wavelength_file: str):

--- a/isofit/test/test_common.py
+++ b/isofit/test/test_common.py
@@ -145,7 +145,7 @@ def test_recursive_replace():
     assert modified_dict3 == dict3
 
 
-def test_interpolators():
+def interp_test(method_a, method_b):
     grid_input = [[1, 5, 10], [2, 4, 6, 7], [50, 60, 80], [0.1, 0.5]]
     data_input = np.random.random(
         (
@@ -157,8 +157,8 @@ def test_interpolators():
         )
     )
 
-    v_orig = VectorInterpolator(grid_input, data_input, version="rg")
-    v_new = VectorInterpolator(grid_input, data_input, version="mlg")
+    v_orig = VectorInterpolator(grid_input, data_input, version=method_a)
+    v_new = VectorInterpolator(grid_input, data_input, version=method_b)
 
     input_test = np.random.random((100, len(grid_input)))
     for _n in range(len(grid_input)):
@@ -177,3 +177,8 @@ def test_interpolators():
         res_orig.flatten(), res_new.flatten()
     )
     assert rvalue**2 > 1 - 1e-6
+
+
+def test_interpolators():
+    interp_test("rg", "mlg")
+    interp_test("rg", "mlg_numba")

--- a/isofit/test/test_common.py
+++ b/isofit/test/test_common.py
@@ -182,3 +182,4 @@ def interp_test(method_a, method_b):
 def test_interpolators():
     interp_test("rg", "mlg")
     interp_test("rg", "mlg_numba")
+    interp_test("rg", "mlg-cache")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "dask",
   "h5py <= 3.14.0",
   "netCDF4 < 1.7.4",
+  "numba",
   "numpy >= 1.20",
   "torch",
   "pyyaml >= 5.3.2",


### PR DESCRIPTION
Not for actual merge as it currently stands, but may warrant some discussion for https://github.com/isofit/isofit/pull/885.

I tried a couple of things here:
1) Reproducing some of the numba results
2) Test some caching strategies for the interpolated points

The takeaways:
- I did get the numba code to run, but I could not reproduce the same level of speed up that you were seeing at the Apply OE level. While being considerably faster on the individual interpolate call level, there is minor evidence that the numba version was faster at the apply oe level, and only in the 1-2% range for speedup.
- The caching strategy did work, was faster on the individual interpolate call level testing, but was not any faster when scaled to an apply oe level.
- This would suggest that the interpolate is not a major bottleneck, which is hinted at in the resource profiles.

Some breakdowns for different interpolation strategies (6249 inversions):

```

Baseline (Idx-Delta point cache_size = 1)

INFO:2026-03-04,15:04:43 ||| 375.09s total
INFO:2026-03-04,15:04:43 ||| 16.6598 spectra/s
INFO:2026-03-04,15:04:43 ||| 1.1107 spectra/s/core
INFO:2026-03-04,15:04:43 ||| All Inversions complete.
INFO:2026-03-04,15:04:43 ||| 375.52s total
INFO:2026-03-04,15:04:43 ||| 16.6407 spectra/s
INFO:2026-03-04,15:04:43 ||| 1.1094 spectra/s/core

Baseline (Idx-Delta Point cache size = 0 unlimited)

INFO:2026-03-04,15:15:33 ||| 373.33s total
INFO:2026-03-04,15:15:33 ||| 16.7387 spectra/s
INFO:2026-03-04,15:15:33 ||| 1.1159 spectra/s/core
INFO:2026-03-04,15:15:33 ||| All Inversions complete.
INFO:2026-03-04,15:15:33 ||| 373.72s total
INFO:2026-03-04,15:15:33 ||| 16.7211 spectra/s
INFO:2026-03-04,15:15:33 ||| 1.1147 spectra/s/core

Interpolated grid point cache results:

INFO:2026-03-04,15:27:57 ||| 384.66s total
INFO:2026-03-04,15:27:57 ||| 16.2454 spectra/s
INFO:2026-03-04,15:27:57 ||| 1.083 spectra/s/core
INFO:2026-03-04,15:27:57 ||| All Inversions complete.
INFO:2026-03-04,15:27:57 ||| 385.08s total
INFO:2026-03-04,15:27:57 ||| 16.2277 spectra/s
INFO:2026-03-04,15:27:57 ||| 1.0818 spectra/s/core

Numba:

INFO:2026-03-04,15:38:47 ||| 370.23s total
INFO:2026-03-04,15:38:47 ||| 16.8787 spectra/s
INFO:2026-03-04,15:38:47 ||| 1.1252 spectra/s/core
INFO:2026-03-04,15:38:47 ||| All Inversions complete.
INFO:2026-03-04,15:38:47 ||| 371.02s total
INFO:2026-03-04,15:38:47 ||| 16.8426 spectra/s
INFO:2026-03-04,15:38:47 ||| 1.1228 spectra/s/core
```